### PR TITLE
feat: add new `exclude_forked` input to block forked repos from copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ commit_message | It is used as a commit message when pushing changes with global
 repos_to_ignore | Comma-separated list of repositories that should not get updates from this action. Action already ignores the repo in which the action is triggered so you do not need to add it explicitly. In the format `repo1,repo2`. | false | -
 topics_to_include | Comma-separated list of topics that should get updates from this action. Repos that do not contain one of the specified topics will get appended to the repos_to_ignore list. In the format `topic1,topic2`. | false | -
 exclude_private | Boolean value on whether to exclude private repositories from this action. | false | false
+exclude_forked | Boolean value on whether to exclude forked repositories from this action. | false | false
 
 ## Examples
 
@@ -118,6 +119,7 @@ jobs:
                 repos_to_ignore: repo1,repo2
                 topics_to_include: topic1,topic2
                 exclude_private: true
+                exclude_forked: true
                 committer_username: santiago-bernabeu
                 committer_email: my-email@me.com
                 commit_message: "ci: update global workflows"

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,11 @@ inputs:
       Boolean value on whether to exclude private repositories from this action.
     default: false
     required: false
+  exclude_forked:
+    description: >
+      Boolean value on whether to exclude forked repositories from this action.
+    default: false
+    required: false
 runs:
   using: node12
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -13398,6 +13398,7 @@ async function run() {
       reposToIgnore: core.getInput('repos_to_ignore'),
       topicsToInclude: core.getInput('topics_to_include'),
       excludePrivate: (core.getInput('exclude_private') === 'true'),
+      excludeForked: (core.getInput('exclude_forked') === 'true'),
     });
 
     /*
@@ -14546,6 +14547,7 @@ async function getListOfFilesToReplicate(octokit, commitId, owner, repo, filesTo
  * @param  {String} inputs.reposToIgnore A comma separated list of repositories to ignore.
  * @param  {String} inputs.topicsToInclude A comma separated list of topics to include.
  * @param  {Boolean} inputs.excludePrivate Exclude private repositories.
+ * @param  {Boolean} inputs.excludeForked Exclude forked repositories.
  * 
  * @returns  {Array}
  */
@@ -14554,6 +14556,7 @@ function getListOfReposToIgnore(repo, reposList, inputs) {
     reposToIgnore,
     topicsToInclude,
     excludePrivate,
+    excludeForked,
   } = inputs;
 
   core.startGroup('Getting list of repos to be ignored');
@@ -14578,6 +14581,11 @@ function getListOfReposToIgnore(repo, reposList, inputs) {
   // Exclude private repositories.
   if (excludePrivate === true) {
     ignoredRepositories.push(...privateRepositories(reposList));
+  }
+
+  // Exclude forked repositories
+  if (excludeForked === true) {
+    ignoredRepositories.push(...forkedRepositories(reposList));
   }
 
   if (!ignoredRepositories.length) {
@@ -14687,6 +14695,18 @@ function archivedRepositories(reposList) {
 function privateRepositories(reposList) {
   return reposList.filter(repo => {
     return repo.private === true;
+  }).map(reposList => reposList.name);
+}
+
+/**
+ * Returns a list of forked repositories.
+ * 
+ * @param  {Array} reposList All the repositories.
+ * @returns {Array}
+ */
+function forkedRepositories(reposList) {
+  return reposList.filter(repo => {
+    return repo.fork === true;
   }).map(reposList => reposList.name);
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1718,6 +1718,7 @@ async function getRepo(octokit, owner, repo) {
     id: data.node_id,
     defaultBranch: data.default_branch,
     private: data.private,
+    fork: data.fork,
     archived: data.archived,
     topics: data.topics,
   };
@@ -1781,6 +1782,7 @@ async function getReposList(octokit, owner) {
       id: repo.node_id,
       defaultBranch: repo.default_branch,
       private: repo.private,
+      fork: repo.fork,
       archived: repo.archived,
       topics: repo.topics,
     };

--- a/lib/api-calls.js
+++ b/lib/api-calls.js
@@ -26,6 +26,7 @@ async function getRepo(octokit, owner, repo) {
     id: data.node_id,
     defaultBranch: data.default_branch,
     private: data.private,
+    fork: data.fork,
     archived: data.archived,
     topics: data.topics,
   };
@@ -89,6 +90,7 @@ async function getReposList(octokit, owner) {
       id: repo.node_id,
       defaultBranch: repo.default_branch,
       private: repo.private,
+      fork: repo.fork,
       archived: repo.archived,
       topics: repo.topics,
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,6 +74,7 @@ async function run() {
       reposToIgnore: core.getInput('repos_to_ignore'),
       topicsToInclude: core.getInput('topics_to_include'),
       excludePrivate: (core.getInput('exclude_private') === 'true'),
+      excludeForked: (core.getInput('exclude_forked') === 'true'),
     });
 
     /*

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,6 +71,7 @@ async function getListOfFilesToReplicate(octokit, commitId, owner, repo, filesTo
  * @param  {String} inputs.reposToIgnore A comma separated list of repositories to ignore.
  * @param  {String} inputs.topicsToInclude A comma separated list of topics to include.
  * @param  {Boolean} inputs.excludePrivate Exclude private repositories.
+ * @param  {Boolean} inputs.excludeForked Exclude forked repositories.
  * 
  * @returns  {Array}
  */
@@ -79,6 +80,7 @@ function getListOfReposToIgnore(repo, reposList, inputs) {
     reposToIgnore,
     topicsToInclude,
     excludePrivate,
+    excludeForked,
   } = inputs;
 
   core.startGroup('Getting list of repos to be ignored');
@@ -103,6 +105,11 @@ function getListOfReposToIgnore(repo, reposList, inputs) {
   // Exclude private repositories.
   if (excludePrivate === true) {
     ignoredRepositories.push(...privateRepositories(reposList));
+  }
+
+  // Exclude forked repositories
+  if (excludeForked === true) {
+    ignoredRepositories.push(...forkedRepositories(reposList));
   }
 
   if (!ignoredRepositories.length) {
@@ -212,5 +219,17 @@ function archivedRepositories(reposList) {
 function privateRepositories(reposList) {
   return reposList.filter(repo => {
     return repo.private === true;
+  }).map(reposList => reposList.name);
+}
+
+/**
+ * Returns a list of forked repositories.
+ * 
+ * @param  {Array} reposList All the repositories.
+ * @returns {Array}
+ */
+function forkedRepositories(reposList) {
+  return reposList.filter(repo => {
+    return repo.fork === true;
   }).map(reposList => reposList.name);
 }


### PR DESCRIPTION
Resolves https://github.com/derberg/global-workflows-support/issues/23

This PR provides new action input that allows you to tell the action to ignore forked repositories